### PR TITLE
fix(php): add support for php 7.3 when running scripts

### DIFF
--- a/scripts/Robo/Plugin/Commands/ExtensionCommands.php
+++ b/scripts/Robo/Plugin/Commands/ExtensionCommands.php
@@ -147,11 +147,13 @@ class ExtensionCommands extends BaseTasks
 
         $composerConfig = json_decode(file_get_contents($composerConfigPath), true);
 
-        $fixPath = fn (string $path) => str_replace(
-            "src/system/library/woovi",
-            "system/library/woovi",
-            $path
-        );
+        $fixPath = function (string $path) {
+            return str_replace(
+                "src/system/library/woovi",
+                "system/library/woovi",
+                $path
+            );
+        };
 
         foreach ($composerConfig["autoload"]["psr-4"] as &$path) {
             $path = $fixPath($path);


### PR DESCRIPTION
Replace arrow functions with normal anonymous functions.