### PR TITLE
fix(system): use OpenCart constant instead of __DIR__

### DIFF
--- a/src/system/library/woovi.php
+++ b/src/system/library/woovi.php
@@ -40,7 +40,7 @@ class Woovi
      */
     public function makeExtension(): Extension
     {
-        require_once __DIR__ . "/woovi/vendor/autoload.php";
+        require_once DIR_SYSTEM . "/library/woovi/vendor/autoload.php";
 
         $extension = new Extension($this->registry);
 


### PR DESCRIPTION
VQMod system modifies OpenCart files in the controllers and library folders.

The change was incorrect because it still maintains the __DIR__ constant, but this constant referred to the original file directory. However a new patched file (as in the image) will be created in the `vqcache` directory and thus `__DIR__` will produce an incorrect value.

![image](https://github.com/Open-Pix/opencart3-woovi/assets/96352451/659aa502-e33b-4d14-9200-85adda9a5376)

By using a constant `DIR_SYSTEM` we maintain a static path.